### PR TITLE
Sketch out cross-references section

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -142,6 +142,25 @@ If you want to add a description to the example, you can use CommonMark
  */
 ```
 
+# Cross referencing documentation
+
+dx comments can link to each other using implicit [link labels](http://spec.commonmark.org/0.28/#link-label)
+provided by the documentation tool. These link labels are expected to direct
+users to other pieces of local documentation or, optionally,
+external documentation for other libraries or systems.
+
+```js
+/**
+ * This pseudorandom generator is useful as a swap-in replacement for
+ * [Math.random] that produces deterministic and predictable values.
+ */
+```
+
+The destination of cross reference links is implementation-specified: some may
+link references like nodejs.org or MDN for external documentation, others may not.
+If a link label isn't defined for a given name, the CommonMark behavior of showing
+the bracketed text should be followed.
+
 ### References
 
 [mdconf]: https://github.com/tj/mdconf

--- a/spec.md
+++ b/spec.md
@@ -161,6 +161,15 @@ link references like nodejs.org or MDN for external documentation, others may no
 If a link label isn't defined for a given name, the CommonMark behavior of showing
 the bracketed text should be followed.
 
+Cross references can be formatted with code spans without affecting their target:
+
+```js
+/**
+ * This wave generator uses [`Math.sin`] to generate smooth sine waves.
+ */
+```
+
+
 ### References
 
 [mdconf]: https://github.com/tj/mdconf


### PR DESCRIPTION
Refs #4: a proposal for how we could do cross-referencing documentation.

TODO/qualms: this really hinges on how we define 'namepaths' or something similar, but this section does not specify that. Which is probably fine, but links are one of the key places where we should determine if, for instance, you can reference `[this.method]` and it will automatically resolve to `MyClass.method` if that's the context of the documentation.